### PR TITLE
fixed access to non-existing regex match result

### DIFF
--- a/check-deps
+++ b/check-deps
@@ -192,21 +192,26 @@ class VersionTest:
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _done: bool = False
 
+    def print_formatted(self, message):
+        output_prefix = f"{self.name} {self.require}"
+        print(f"{output_prefix:25}: {message}")
+
+    def print_not_found(self):
+        self.print_formatted("not found")
+
     @async_cache
     async def run(self, recurse):
         for dep in self.depends:
             if not await recurse(dep):
                 return Result(self, False,
                               failure_text=f"Failed dependency: {dep}")
-
-        col1 = f"{self.name} {self.require}"
         proc = await asyncio.create_subprocess_shell(
             self.get_version,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
         (stdout, stderr) = await proc.communicate()
         if proc.returncode != 0:
-            print(f"{col1:25}: not found")
+            self.print_not_found()
             return Result(
                 self,
                 success=False,
@@ -214,17 +219,21 @@ class VersionTest:
         try:
             if self.pattern is not None:
                 m = re.match(self.pattern, stdout.decode())
-                out, _ = parse_version(m.group(1).strip())
+                if m is not None:
+                    out, _ = parse_version(m.group(1).strip())
+                else:
+                    self.print_not_found()
+                    return Result(self, False, failure_text=f"No regex match on pattern '{self.pattern}'")
             else:
                 out, _ = parse_version(stdout.decode().strip())
         except ConfigError as e:
             return Result(self, False, failure_text=str(e))
 
         if self.require(out):
-            print(f"{col1:25}: {str(out):10} Ok")
+            self.print_formatted(f"{str(out):10} Ok")
             return Result(self, True)
         else:
-            print(f"{col1:25}: {str(out):10} Fail")
+            self.print_formatted(f"{str(out):10} Fail")
             return Result(self, False, failure_text="Too old.",
                           found_version=out)
 


### PR DESCRIPTION
- The pattern might not match, so the match variable `m` is `None`.
- Wrote some defensive code around that.
- Factored out printing of messages, which is now used in four places.